### PR TITLE
following functionality

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3666,9 +3666,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17837,9 +17837,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -17847,7 +17847,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/src/components/common/Rightbar.jsx
+++ b/frontend/src/components/common/Rightbar.jsx
@@ -1,9 +1,52 @@
 import { Link } from "react-router-dom";
 import RightPanelSkeleton from "../skeletons/RightPanelSkeleton";
 import { USERS_FOR_RIGHT_PANEL } from "../../utils/db/dummy";
+import { useState, useEffect } from "react";
+import axios from "axios";
+import Cookies from 'js-cookie';
+import { jwtDecode } from "jwt-decode";
 
 const RightPanel = () => {
 	const isLoading = false;
+
+	const [userIdFromCookie, setUserIdFromCookie] = useState("");
+	const [followedUsers, setFollowedUsers] = useState([]); // Track followed users
+
+  
+	useEffect(() => {
+  	// get user ID from JWT token in cookie
+	  const cookieValue = Cookies.get("tuneshare_cookie");
+	  let currentUserId = "";
+	  if (cookieValue) {
+		  const decodedToken = jwtDecode(cookieValue);
+		  currentUserId = decodedToken.user_id;
+		  setUserIdFromCookie(currentUserId);
+		  //console.log("User ID from cookie:", userIdFromCookie);
+	  } else {
+	  console.log("No token found in the cookie.");}
+  }, []);
+
+
+    // Handle Follow Action
+	const handleFollow = async (targetUserId) => {
+		 //console.log(`Following user: ${targetUserId}`);
+		try {
+		  const response = await axios.post('/api/follow', {
+			userID: userIdFromCookie,
+			target_userID: targetUserId,
+		  });
+	
+		  if (response.data.success) {
+			console.log(`Successfully followed user: ${targetUserId}`);
+			setFollowedUsers((prev) => [...prev, targetUserId]); // Update the list of followed users
+		  } else {
+			console.error("Failed to follow user:", response.data.message);
+		  }
+		} catch (error) {
+		  console.error("Error while following user:", error);
+		}
+	  };
+
 
 	return (
 		<div className='hidden lg:block my-4 mx-2'>
@@ -43,7 +86,10 @@ const RightPanel = () => {
 								<div>
 									<button
 										className='btn bg-white text-black hover:bg-white hover:opacity-90 rounded-full btn-sm'
-										onClick={(e) => e.preventDefault()}
+										onClick={(e) => {
+											e.preventDefault();
+											handleFollow(user._id);			
+										  }}
 									>
 										Follow
 									</button>

--- a/frontend/src/pages/Profile/ProfilePage.jsx
+++ b/frontend/src/pages/Profile/ProfilePage.jsx
@@ -22,12 +22,47 @@ const ProfilePage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [userIdFromCookie, setUserIdFromCookie] = useState("");
-
+  const [showFollowAlert, setShowFollowAlert] = useState(false);
 
   const coverImgRef = useRef(null);
   const profileImgRef = useRef(null);
 
   const { userId } = useParams(); // get userId from URL parameters
+
+
+
+     // Handle Follow Action
+	const handleFollow = async (targetUserId) => {
+   try {
+     const res = await axios.post('/api/follow', {
+     userID: userIdFromCookie,
+     target_userID: targetUserId,
+     });
+ 
+     if (res.data.success) {
+     console.log(`Successfully followed user: ${targetUserId}`);
+     setShowFollowAlert(true); // Show alert
+     setTimeout(() => setShowFollowAlert(false), 5000); // Hide after 3 seconds
+     
+     } else if (res.data.error) {
+     console.error("Failed to follow user:", res.data.message);
+     }
+   } catch (error) {
+    if (error.response) {
+      // Handle 409 specifically
+      if (error.response.status === 409) {
+        console.error("User is already following this user.");
+        console.error("Error message:", error.response.data.message);
+      } else {
+        // Handle other response errors
+        console.error("Error response:", error.response.data.message);
+      }
+    } else {
+      // Handle network errors or other unexpected issues
+      console.error("Error while following user:", error.message);
+    }
+  }
+   };
 
   useEffect(() => {
     // get user ID from JWT token in cookie
@@ -37,7 +72,6 @@ const ProfilePage = () => {
       const decodedToken = jwtDecode(cookieValue);
       currentUserId = decodedToken.user_id;
       setUserIdFromCookie(currentUserId);
-      console.log("User ID from cookie:", userIdFromCookie);
     } else {
       console.log("No token found in the cookie.");
     }
@@ -52,7 +86,7 @@ const ProfilePage = () => {
         });
 
         if (response.data.success) {
-          console.log(response.data.data);
+          //console.log(response.data.data);
           setUserData(response.data.data.user);
           setPosts(response.data.data.posts);
           setError(null);
@@ -95,6 +129,11 @@ const ProfilePage = () => {
         <div className="flex flex-col">
           {!isLoading && userData && (
             <>
+              {showFollowAlert && (
+                <div className="alert alert-success">
+                  Successfully followed user!
+               </div>
+            )}
               <div className="flex gap-10 px-4 py-2 items-center">
                 <Link to="/">
                   <FaArrowLeft className="w-4 h-4" />
@@ -163,7 +202,10 @@ const ProfilePage = () => {
                 {!isMyProfile && (
                   <button
                     className="btn btn-outline rounded-full btn-sm"
-                    onClick={() => alert("Followed successfully")}
+                    onClick={(e) => {
+											e.preventDefault();
+											handleFollow(userId);			
+										  }} 
                   >
                     Follow
                   </button>
@@ -171,8 +213,9 @@ const ProfilePage = () => {
                 {(coverImg || profileImg) && isMyProfile && (
                   <button
                     className="btn btn-primary rounded-full btn-sm text-white px-4 ml-2"
-                    onClick={() => alert("Profile updated successfully")}
-                  >
+										onClick={(e) => {
+											e.preventDefault();	
+										  }}                  >
                     Update
                   </button>
                 )}


### PR DESCRIPTION
Can now follow other users. 

When searching for another user via their ID with profile/"ID", in the URL, they can now be followed, showing a follow success message in the console, and to the user. This will update the database using the follow route from the blackened, which updates following/follwer arrays for each user.  

If the user is already followed in the database, clicking the follow button will not display an error message for the user yet, but the console will show the error. You'll notice that this case is caught in both the front end and blackened. This was necessary because AXIOS sees any error as just an error, and won't return the error message in the route's res body.

I also added some of the follow functions to the right side bar file, but these aren't operational yet since we don't have real users displayed on the sidebar. 

