### PR TITLE
Adding backend routes for handling likes on posts

### DIFF
--- a/backend/routes/likes.js
+++ b/backend/routes/likes.js
@@ -7,19 +7,19 @@ router.post("/like", async (req, res) => {
         return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
     }
 
-    const postID = req.body.targetUserID;
+    const postID = req.body.postID;
 
     try {
-        const post = await Post.findOne({ post_id: postID});
+        const post = await Post.findOne({post_id: postID});
         if (!post) {
-           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+           if(!post){ return res.status(404).send({success: false, message: "Post does not exist" });}
         }
 
         post.likes += 1;
         await post.save();
-        return res.status(200).json({success: true, message: "post liked successfully"})
+        return res.status(200).send({success: true, message: "post liked successfully"})
     } catch (error) {
-        return res.status(500).json({success: false, message: "Server error", error: error.message});
+        return res.status(500).send({success: false, message: "Server error", error: error.message});
     }
 
 });
@@ -31,44 +31,45 @@ router.post("/unlike", async (req, res) => {
         return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
     }
 
-    const postID = req.body.targetUserID;
+    const postID = req.body.postID;
 
     try {
-        const post = await Post.findOne({ post_id: postID});
+        const post = await Post.findOne({post_id: postID});
         if (!post) {
-           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+           if(!post){ return res.status(404).send({success: false, message: "Post does not exist" });}
         }
         if (post.likes > 0) { // add this check to avoid having negative like counts
             post.likes -= 1;
         } 
         await post.save();
-        return res.status(200).json({success: true, message: "post unliked successfully"})
+        return res.status(200).send({success: true, message: "post unliked successfully"})
     } catch (error) {
-        return res.status(500).json({success: false, message: "Server error", error: error.message});
+        return res.status(500).send({success: false, message: "Server error", error: error.message});
     }
 });
 
 
 // get method to get like counts 
 // takes in a postID value and returns a number representing the like count of a post
-router.get("/like", async (req, res) => {
+router.get("/like-count", async (req, res) => {
     if (!req.body.postID) {
         return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
     }
 
-    const postID = req.body.targetUserID;
+    const postID = req.body.postID;
 
     try {
-        const post = await Post.findOne({ post_id: postID});
+        const post = await Post.findOne({post_id: postID});
 
         if (!post) {
-           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+           if(!post){ return res.status(404).send({success: false, message: "Post does not exist"});}
         }
 
-        post.likes += 1;
-        await post.save();
+        const likeCount = post.likes;
+
+        return res.status(200).send({success:true, message: "like count retrieved successfully", data: {likes: likeCount}})
     } catch (error) {
-        return res.status(500).json({success: false, message: "Server error", error: error.message});
+        return res.status(500).send({success: false, message: "Server error", error: error.message});
     }
 
 });

--- a/backend/routes/likes.js
+++ b/backend/routes/likes.js
@@ -1,0 +1,76 @@
+const express = require("express");
+let router = express.Router();
+const Post = require("../models/post.js");
+
+router.post("/like", async (req, res) => {
+    if (!req.body.postID) {
+        return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
+    }
+
+    const postID = req.body.targetUserID;
+
+    try {
+        const post = await Post.findOne({ post_id: postID});
+        if (!post) {
+           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+        }
+
+        post.likes += 1;
+        await post.save();
+        return res.status(200).json({success: true, message: "post liked successfully"})
+    } catch (error) {
+        return res.status(500).json({success: false, message: "Server error", error: error.message});
+    }
+
+});
+
+// post method to unlike a post
+// takes in a postID value and decreases the number of likes of a post by one
+router.post("/unlike", async (req, res) => {
+    if (!req.body.postID) {
+        return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
+    }
+
+    const postID = req.body.targetUserID;
+
+    try {
+        const post = await Post.findOne({ post_id: postID});
+        if (!post) {
+           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+        }
+        if (post.likes > 0) { // add this check to avoid having negative like counts
+            post.likes -= 1;
+        } 
+        await post.save();
+        return res.status(200).json({success: true, message: "post unliked successfully"})
+    } catch (error) {
+        return res.status(500).json({success: false, message: "Server error", error: error.message});
+    }
+});
+
+
+// get method to get like counts 
+// takes in a postID value and returns a number representing the like count of a post
+router.get("/like", async (req, res) => {
+    if (!req.body.postID) {
+        return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
+    }
+
+    const postID = req.body.targetUserID;
+
+    try {
+        const post = await Post.findOne({ post_id: postID});
+
+        if (!post) {
+           if(!user){ return res.status(404).json({success: false, message: "Post does not exist" });}
+        }
+
+        post.likes += 1;
+        await post.save();
+    } catch (error) {
+        return res.status(500).json({success: false, message: "Server error", error: error.message});
+    }
+
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ const followUserRoutes = require('./routes/follow_route.js');
 const createPostRoutes = require('./routes/post_creation.js');
 const profileRoutes = require('./routes/profile.js');
 const userSearchRoutes = require('./routes/user_search.js')
+const likesRoutes = require('./routes/likes.js');
 
 dotenv.config();
 const PORT = 8080;
@@ -41,6 +42,7 @@ app.use('/api', followUserRoutes);
 app.use('/api', createPostRoutes);
 app.use('/api', profileRoutes);
 app.use('/api', userSearchRoutes)
+app.use('/api', likesRoutes);
 
 app.use(defaultRoute);
 app.use(invalidRoutes); // THIS HAS TO STAY LAST

--- a/backend/tests/likes.test.js
+++ b/backend/tests/likes.test.js
@@ -1,0 +1,155 @@
+const express = require("express");
+const request = require("supertest");
+const router = require("../routes/likes.js"); 
+jest.mock("../models/post.js"); 
+
+const Post = require("../models/post.js");
+
+const app = express();
+app.use(express.json());
+app.use("/", router);
+
+const postID = "123";
+
+describe("POST /like", () => {
+    beforeEach(() => {
+        jest.clearAllMocks(); 
+    });
+
+    it("should return 400 if postID is missing", async () => {
+        const res = await request(app).post("/like").send({}); // no postID was given, should not proceed
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({success: false, message: "Missing required parameter: postID"});
+    });
+
+    it("should return 404 if the post does not exist", async () => {
+        Post.findOne.mockResolvedValueOnce(null); 
+
+        const res = await request(app).post("/like").send({postID: postID});
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({success: false, message: "Post does not exist"});
+    });
+
+    it("should return 200 and increment likes if the post exists", async () => {
+        const mockPost = {post_id: postID, likes: 5, save: jest.fn() };
+        Post.findOne.mockResolvedValueOnce(mockPost); 
+
+        const res = await request(app).post("/like").send({postID: postID});
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({success: true, message: "post liked successfully"});
+
+        expect(mockPost.likes).toBe(6);
+        expect(mockPost.save).toHaveBeenCalled();
+    });
+
+    it("should return 500 if there is a server error", async () => {
+        Post.findOne.mockRejectedValueOnce(new Error("Database error"));
+
+        const res = await request(app).post("/like").send({postID: postID});
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({success: false, message: "Server error", error: "Database error"});
+    });
+});
+
+describe("POST /unlike", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return 400 if postID is missing", async () => {
+        const res = await request(app).post("/unlike").send({});
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({success: false, message: "Missing required parameter: postID"});
+    });
+
+    it("should return 404 if the post does not exist", async () => {
+        Post.findOne.mockResolvedValueOnce(null); 
+
+        const res = await request(app).post("/unlike").send({postID: postID});
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({success: false, message: "Post does not exist"});
+    });
+
+    it("should return 200 and decrement likes if the post exists and likes > 0", async () => {
+        const mockPost = {post_id: postID, likes: 5, save: jest.fn() };
+        Post.findOne.mockResolvedValueOnce(mockPost); 
+
+        const res = await request(app).post("/unlike").send({postID: postID});
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({success: true, message: "post unliked successfully"});
+
+        expect(mockPost.likes).toBe(4);
+        expect(mockPost.save).toHaveBeenCalled();
+    });
+
+    it("should not decrement likes below 0", async () => {
+        const mockPost = {post_id: postID, likes: 0, save: jest.fn() };
+        Post.findOne.mockResolvedValueOnce(mockPost);
+
+        const res = await request(app).post("/unlike").send({postID: postID});
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({success: true, message: "post unliked successfully"});
+
+        expect(mockPost.likes).toBe(0);
+        expect(mockPost.save).toHaveBeenCalled();
+    });
+
+    it("should return 500 if there is a server error", async () => {
+        Post.findOne.mockRejectedValueOnce(new Error("Database error"));
+
+        const res = await request(app).post("/unlike").send({postID: postID});
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({success: false, message: "Server error", error: "Database error"});
+    });
+});
+
+describe("GET /like", () => {
+    beforeEach(() => {
+        jest.clearAllMocks(); 
+    });
+
+    it("should return 400 if postID is missing", async () => {
+        const res = await request(app).get("/like-count").send({});
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({success: false, message: "Missing required parameter: postID"});
+    });
+
+    it("should return 404 if the post does not exist", async () => {
+        Post.findOne.mockResolvedValueOnce(null);
+
+        const res = await request(app).get("/like-count").send({postID: postID});
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body).toEqual({success: false, message: "Post does not exist"});
+    });
+
+    it("should return 200 and the like count if the post exists", async () => {
+        const mockPost = {post_id: postID, likes: 10};
+        Post.findOne.mockResolvedValueOnce(mockPost); 
+
+        const res = await request(app).get("/like-count").send({postID: postID});
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({success: true, message: "like count retrieved successfully", data: {likes: 10}});
+    });
+
+    it("should return 500 if there is a server error", async () => {
+        // Simulate a database error
+        Post.findOne.mockRejectedValueOnce(new Error("Database error"));
+
+        const res = await request(app).get("/like-count").send({postID: postID});
+
+        expect(res.statusCode).toBe(500);
+        expect(res.body).toEqual({success: false, message: "Server error", error: "Database error"});
+    });
+});


### PR DESCRIPTION
# Description
Added new backend routes for handling likes on posts

# Changes
This PR includes changes such as

1. Added a POST route `like` to like a post given a `postID`
2. Added a POST route `unlike` to unlike a post given a `postID`
3. Added a GET route `get-likes` for getting the number of likes of a post given a `postID`
4. Added new likes routes to server file

# Tests
### Backend Tests
- [x] Unit Tests
<img width="702" alt="image" src="https://github.com/user-attachments/assets/61c35e18-5943-46b4-b941-d6216cd95867" />

 