### PR TITLE
Likes frontend

### DIFF
--- a/backend/routes/likes.js
+++ b/backend/routes/likes.js
@@ -51,7 +51,7 @@ router.post("/unlike", async (req, res) => {
 
 // get method to get like counts 
 // takes in a postID value and returns a number representing the like count of a post
-router.get("/like-count", async (req, res) => {
+router.post("/like-count", async (req, res) => {
     if (!req.body.postID) {
         return res.status(400).send({ success: false, message: "Missing required parameter: postID" });
     }

--- a/backend/tests/likes.test.js
+++ b/backend/tests/likes.test.js
@@ -112,13 +112,13 @@ describe("POST /unlike", () => {
     });
 });
 
-describe("GET /like", () => {
+describe("POST /like", () => {
     beforeEach(() => {
         jest.clearAllMocks(); 
     });
 
     it("should return 400 if postID is missing", async () => {
-        const res = await request(app).get("/like-count").send({});
+        const res = await request(app).post("/like-count").send({});
 
         expect(res.statusCode).toBe(400);
         expect(res.body).toEqual({success: false, message: "Missing required parameter: postID"});
@@ -127,7 +127,7 @@ describe("GET /like", () => {
     it("should return 404 if the post does not exist", async () => {
         Post.findOne.mockResolvedValueOnce(null);
 
-        const res = await request(app).get("/like-count").send({postID: postID});
+        const res = await request(app).post("/like-count").send({postID: postID});
 
         expect(res.statusCode).toBe(404);
         expect(res.body).toEqual({success: false, message: "Post does not exist"});
@@ -137,7 +137,7 @@ describe("GET /like", () => {
         const mockPost = {post_id: postID, likes: 10};
         Post.findOne.mockResolvedValueOnce(mockPost); 
 
-        const res = await request(app).get("/like-count").send({postID: postID});
+        const res = await request(app).post("/like-count").send({postID: postID});
 
         expect(res.statusCode).toBe(200);
         expect(res.body).toEqual({success: true, message: "like count retrieved successfully", data: {likes: 10}});
@@ -147,7 +147,7 @@ describe("GET /like", () => {
         // Simulate a database error
         Post.findOne.mockRejectedValueOnce(new Error("Database error"));
 
-        const res = await request(app).get("/like-count").send({postID: postID});
+        const res = await request(app).post("/like-count").send({postID: postID});
 
         expect(res.statusCode).toBe(500);
         expect(res.body).toEqual({success: false, message: "Server error", error: "Database error"});

--- a/frontend/src/components/common/Post.jsx
+++ b/frontend/src/components/common/Post.jsx
@@ -6,6 +6,8 @@ import { FaTrash } from "react-icons/fa";
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import axios from "axios";
+import Cookies from "js-cookie";
+import { jwtDecode } from "jwt-decode";
 
 // get access token
 const getSpotifyAccessToken = async () => {
@@ -43,7 +45,6 @@ const getSpotifyTrackMetadata = async (spotifyUrl) => {
             },
         });
         
-        console.log("Track Metadata:", response.data);
         return response.data;
     } catch (error) {
         console.error("Error fetching track metadata:", error);
@@ -53,12 +54,15 @@ const getSpotifyTrackMetadata = async (spotifyUrl) => {
 const Post = ({ post }) => {
     const [comment, setComment] = useState("");
     const [trackMetadata, setTrackMetadata] = useState(null);
+    const [isLiked, setIsLiked] = useState(false);
+
 
     const postOwner = post;
-    const isLiked = false;
     const isMyPost = true;
     const formattedDate = "1h";
     const isCommenting = false;
+    const postID = post.post_id;
+    const [userIdFromCookie, setUserIdFromCookie] = useState("");
 
     useEffect(() => {
         const fetchMetadata = async () => {
@@ -68,13 +72,38 @@ const Post = ({ post }) => {
             }
         };
         fetchMetadata();
+
+        // get user ID from JWT token in cookie
+        let currentUserId = "";
+        const cookieValue = Cookies.get("tuneshare_cookie");
+        if (cookieValue) {
+          const decodedToken = jwtDecode(cookieValue);
+          currentUserId = decodedToken.user_id;
+          setUserIdFromCookie(currentUserId);
+        } else {
+          console.log("No token found in the cookie.");
+        }
     }, [post.song_link]);
 
     const handleDeletePost = () => {};
     const handlePostComment = (e) => {
         e.preventDefault();
     };
-    const handleLikePost = () => {};
+    const handleLikePost = async () => {
+        if (isLiked) {
+            const res = await axios.post('/api/like', {
+                postID: postID,
+            });
+            setIsLiked(true);
+            console.log(res);
+        } else {
+            const res = await axios.post('/api/unlike', {
+                postID: postID,
+            });
+            setIsLiked(false);
+            console.log(res);
+        }
+    };
 
     return (
         <>

--- a/frontend/src/components/common/Post.jsx
+++ b/frontend/src/components/common/Post.jsx
@@ -82,7 +82,7 @@ const Post = ({ post }) => {
             }
         };
         fetchMetadata();
-        const likes = getLikeCount(postID);
+        setLikes(post.likes || 0);
     
 
 
@@ -103,19 +103,24 @@ const Post = ({ post }) => {
         e.preventDefault();
     };
     const handleLikePost = async () => {
-        if (isLiked) {
-            const res = await axios.post('/api/like', {
-                postID: postID,
-            });
-            setIsLiked(true);
-            console.log(res);
-        } else {
-            const res = await axios.post('/api/unlike', {
-                postID: postID,
-            });
-            setIsLiked(false);
-            console.log(res);
+        try {
+            let newLikes;
+            if (isLiked) {
+                const res = await axios.post('/api/unlike', { postID: postID });
+                if (res.status == 200) newLikes = likes - 1; 
+                setIsLiked(false);
+            } else {
+                const res = await axios.post('/api/like', { postID: postID });
+                if (res.status == 200) newLikes = likes + 1; 
+                setIsLiked(true);
+            }
+    
+            setLikes(newLikes);
+            console.log(`Updated likes count: ${newLikes}`);
+        } catch (error) {
+            console.error("Error updating likes:", error);
         }
+    
     };
 
     return (
@@ -297,7 +302,7 @@ const Post = ({ post }) => {
                                         isLiked ? "text-pink-500" : ""
                                     }`}
                                 >
-                                    {post.likes.length}
+                                    {likes}
                                 </span>
                             </div>
                         </div>

--- a/frontend/src/components/common/Post.jsx
+++ b/frontend/src/components/common/Post.jsx
@@ -51,10 +51,20 @@ const getSpotifyTrackMetadata = async (spotifyUrl) => {
     }
 };
 
+const getLikeCount = async (postID) => {
+    console.log("post id" + postID);
+    const res = await axios.post('/api/like-count', {
+        postID: postID,
+    });
+    console.log(res);
+    return res.data.likes | 0;
+}
+
 const Post = ({ post }) => {
     const [comment, setComment] = useState("");
     const [trackMetadata, setTrackMetadata] = useState(null);
     const [isLiked, setIsLiked] = useState(false);
+    const [likes, setLikes] = useState(null)
 
 
     const postOwner = post;
@@ -72,6 +82,9 @@ const Post = ({ post }) => {
             }
         };
         fetchMetadata();
+        const likes = getLikeCount(postID);
+    
+
 
         // get user ID from JWT token in cookie
         let currentUserId = "";


### PR DESCRIPTION
# Description
Connected likes backend with frontend, we can now like posts 🤓

# Changes
This PR includes changes such as

1. Changed like-count route from `GET` to `POST` 
2. Updated unit tests for point 1 code
3. Added frontend logic to handle likes on posts

# Tests
### Backend Tests
- [x] Unit Tests
<img width="372" alt="image" src="https://github.com/user-attachments/assets/2b1761c3-fbbf-4397-856c-61f2fa985930" />


hitting the like button -> +1 like
hitting it again -> -1 like
<img width="196" alt="image" src="https://github.com/user-attachments/assets/17d3278b-797e-4f3c-9b4a-190cbd171b44" />
<img width="105" alt="image" src="https://github.com/user-attachments/assets/e3ddfb0e-7030-4998-b62a-bd58620838c8" />

# Future work
There is a bug: if a user likes a post and then reloads the page then the same user can like the same exact post again even though they already liked it.
Fixing this will require changes to the database models, the routes, and the frontend `Post` page, so it is best to include it in a future PR so this current one remains small and manageable.

 