### PR TITLE
Access token optimization

### DIFF
--- a/backend/models/songs.js
+++ b/backend/models/songs.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+const songSchema = new mongoose.Schema(
+    {
+        song_id: { type: String, default: uuidv4 }, 
+        song_link: { type: String, required: true }, // Link to the song
+        song_name:
+        artist_name:
+        album_name:
+        
+        created_at: { type: Date, default: Date.now }
+    }
+);
+
+const Song = mongoose.model('Song', songSchema);
+module.exports = Song;

--- a/frontend/src/components/common/Post.jsx
+++ b/frontend/src/components/common/Post.jsx
@@ -220,7 +220,7 @@ const Post = ({ post, likedPosts, accessToken }) => {
   };
 
   const togglePlayPause = async () => {
-    if (!post.song_link) return;
+    if (!post.song_link || !accessToken) return;
 
     // Stop any existing audio before playing a new one
     if (audio) {
@@ -231,7 +231,7 @@ const Post = ({ post, likedPosts, accessToken }) => {
 
     if (!isPlaying) {
       if (!previewUrl) {
-        const preview = await get30SecPreview(post.song_link);
+        const preview = await get30SecPreview(post.song_link, accessToken);
         if (preview) {
           setPreviewUrl(preview);
           const newAudio = new Audio(preview);

--- a/frontend/src/components/common/Posts.jsx
+++ b/frontend/src/components/common/Posts.jsx
@@ -9,6 +9,37 @@ const Posts = ({ context, profileUserId }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [posts, setPosts] = useState([]);
     const [likedPosts, setLikedPosts] = useState([]);
+    const [accessToken, setAccessToken] = useState("")
+
+    const getSpotifyAccessToken = async () => {
+        const client_id = import.meta.env.VITE_CLIENT_ID;
+        const client_secret = import.meta.env.VITE_CLIENT_SECRET;
+        const response = await axios.post(
+          "https://accounts.spotify.com/api/token",
+          new URLSearchParams({ grant_type: "client_credentials" }),
+          {
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+              Authorization: `Basic ${btoa(`${client_id}:${client_secret}`)}`,
+            },
+          }
+        );
+        return response.data.access_token;
+      };
+    
+      // 1. Fetch Spotify token once on mount
+      useEffect(() => {
+        const fetchAccessToken = async () => {
+          try {
+            const token = await getSpotifyAccessToken();
+            setAccessToken(token);
+          } catch (err) {
+            console.error("Error fetching Spotify token:", err);
+          }
+        };
+        fetchAccessToken();
+      }, []);
+    
 
     useEffect(() => {
         const fetchPosts = async () => {
@@ -74,7 +105,7 @@ const Posts = ({ context, profileUserId }) => {
             {!isLoading && posts && (
                 <div>
                     {posts.map((post) => (
-                        <Post key={post._id} post={post} likedPosts={likedPosts}/>
+                        <Post key={post._id} post={post} likedPosts={likedPosts} accessToken={accessToken}/>
                     ))}
                 </div>
             )}


### PR DESCRIPTION
Previously we were getting a new access token for every call to the spotify api, now we only get one and reuse it for every call to the spotify api, which should give us more room before we get rate limited