### PR TITLE
Saving song metadata to DB to reduce spotify API usage

### DIFF
--- a/backend/models/songs.js
+++ b/backend/models/songs.js
@@ -1,12 +1,20 @@
 const mongoose = require('mongoose');
+const { v4: uuidv4 } = require("uuid");
 
 const songSchema = new mongoose.Schema(
     {
         song_id: { type: String, default: uuidv4 }, 
         song_link: { type: String, required: true }, // Link to the song
-        song_name:
-        artist_name:
-        album_name:
+
+        spotify_song_id: { type: String, required: true},
+        song_name: { type: String, required: true},
+        artist_names: [{ type: String, required: true}],
+        album_name: { type: String },
+        album_image_url: { type: String },
+        preview_url: { type: String }, // 30-sec preview
+        duration_ms: { type: Number }, // track length
+        explicit: { type: Boolean },
+        deezer_preview_url: { type: String },
         
         created_at: { type: Date, default: Date.now }
     }

--- a/backend/models/songs.js
+++ b/backend/models/songs.js
@@ -15,7 +15,8 @@ const songSchema = new mongoose.Schema(
         duration_ms: { type: Number }, // track length
         explicit: { type: Boolean },
         deezer_preview_url: { type: String },
-        
+        deezer_url: { type: String},
+    
         created_at: { type: Date, default: Date.now }
     }
 );

--- a/backend/routes/songs.js
+++ b/backend/routes/songs.js
@@ -15,15 +15,15 @@ router.post("/song-metadata", async (req, res) => {
 	const body = req.body;
 
 	if (!body || typeof body !== "object") {
-		return res.status(400).json({ success: false, message: "Missing request body." });
+		return res.status(400).json({ success: false, message: "missing request body" });
 	}
 
 	if (!body.spotifyUrl) {
-		return res.status(400).json({ success: false, message: "Missing spotifyUrl." });
+		return res.status(400).json({ success: false, message: "missing spotifyUrl" });
 	}
 
 	if (!body.spotifyToken) {
-		return res.status(400).json({ success: false, message: "Missing spotifyToken." });
+		return res.status(400).json({ success: false, message: "missing spotifyToken" });
 	}
 
 	const spotifyUrl = body.spotifyUrl;
@@ -31,14 +31,13 @@ router.post("/song-metadata", async (req, res) => {
 
 	const spotifyId = extractSpotifyId(spotifyUrl);
 	if (!spotifyId) {
-		return res.status(400).json({ success: false, message: "Invalid Spotify URL." });
+		return res.status(400).json({ success: false, message: "invalid Spotify URL" });
 	}
 
 	try {
 		// Check DB cache
 		const existing = await Song.findOne({ spotify_song_id: spotifyId });
 		if (existing) {
-			console.log("✅ [Metadata] Fetched from database (already cached)");
 			return res.json({ success: true, data: existing, from: "db" });
 		}
 
@@ -65,12 +64,9 @@ router.post("/song-metadata", async (req, res) => {
 				const topResult = deezerResp.data.data[0];
 				deezerPreview = topResult.preview || null;
 				deezerUrl = topResult.link || null;
-				console.log("🎧 [Deezer] Found track:", deezerUrl);
 			} else {
-				console.log("⚠️ [Deezer] No match found.");
 			}
 		} catch (deezerErr) {
-			console.warn("❌ [Deezer] Search failed:", deezerErr.message);
 		}
 
 		// Save song to DB (Spotify + Deezer info)
@@ -88,12 +84,10 @@ router.post("/song-metadata", async (req, res) => {
 			deezer_url: deezerUrl,
 		});
 
-		console.log("✅ [Metadata] Fetched from Spotify API (and saved to DB)");
 		res.json({ success: true, data: newSong, from: "spotify" });
 
 	} catch (err) {
-		console.error("❌ error in /api/song-metadata:", err.message);
-		res.status(500).json({ success: false, message: "Internal server error." });
+		res.status(500).json({ success: false, message: "Internal server error" });
 	}
 });
 

--- a/backend/routes/songs.js
+++ b/backend/routes/songs.js
@@ -1,0 +1,100 @@
+const express = require("express");
+const router = express.Router();
+const Song = require("../models/songs.js");
+const axios = require("axios");
+
+const extractSpotifyId = (url) => {
+	try {
+		return url.split("/track/")[1].split("?")[0];
+	} catch {
+		return null;
+	}
+};
+
+router.post("/song-metadata", async (req, res) => {
+	const body = req.body;
+
+	if (!body || typeof body !== "object") {
+		return res.status(400).json({ success: false, message: "Missing request body." });
+	}
+
+	if (!body.spotifyUrl) {
+		return res.status(400).json({ success: false, message: "Missing spotifyUrl." });
+	}
+
+	if (!body.spotifyToken) {
+		return res.status(400).json({ success: false, message: "Missing spotifyToken." });
+	}
+
+	const spotifyUrl = body.spotifyUrl;
+	const spotifyToken = body.spotifyToken;
+
+	const spotifyId = extractSpotifyId(spotifyUrl);
+	if (!spotifyId) {
+		return res.status(400).json({ success: false, message: "Invalid Spotify URL." });
+	}
+
+	try {
+		// Check DB cache
+		const existing = await Song.findOne({ spotify_song_id: spotifyId });
+		if (existing) {
+			console.log("✅ [Metadata] Fetched from database (already cached)");
+			return res.json({ success: true, data: existing, from: "db" });
+		}
+
+		// Fetch from Spotify
+		const response = await axios.get(`https://api.spotify.com/v1/tracks/${spotifyId}`, {
+			headers: { Authorization: `Bearer ${spotifyToken}` },
+			params: { market: "US" },
+		});
+
+		const track = response.data;
+
+		// Always attempt Deezer match
+		let deezerPreview = null;
+		let deezerUrl = null;
+
+		try {
+			const deezerResp = await axios.get("http://localhost:8080/api/deezer-search", {
+				params: {
+					query: `${track.artists[0].name} ${track.name}`,
+				},
+			});
+
+			if (deezerResp.data.data.length > 0) {
+				const topResult = deezerResp.data.data[0];
+				deezerPreview = topResult.preview || null;
+				deezerUrl = topResult.link || null;
+				console.log("🎧 [Deezer] Found track:", deezerUrl);
+			} else {
+				console.log("⚠️ [Deezer] No match found.");
+			}
+		} catch (deezerErr) {
+			console.warn("❌ [Deezer] Search failed:", deezerErr.message);
+		}
+
+		// Save song to DB (Spotify + Deezer info)
+		const newSong = await Song.create({
+			song_link: spotifyUrl, // Spotify full link
+			spotify_song_id: track.id,
+			song_name: track.name,
+			artist_names: track.artists.map((a) => a.name),
+			album_name: track.album.name,
+			album_image_url: track.album.images?.[0]?.url || "",
+			preview_url: track.preview_url || null,
+			duration_ms: track.duration_ms,
+			explicit: track.explicit,
+			deezer_preview_url: deezerPreview,
+			deezer_url: deezerUrl,
+		});
+
+		console.log("✅ [Metadata] Fetched from Spotify API (and saved to DB)");
+		res.json({ success: true, data: newSong, from: "spotify" });
+
+	} catch (err) {
+		console.error("❌ error in /api/song-metadata:", err.message);
+		res.status(500).json({ success: false, message: "Internal server error." });
+	}
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -19,7 +19,8 @@ const userSearchRoutes = require('./routes/user_search.js')
 const likesRoutes = require('./routes/likes.js');
 const deezerRoutes = require('./routes/deezer.js');
 const suggUsersRoutes = require('./routes/suggestedUsers.js');
-const commentsRoutes = require('./routes/comments.js')
+const commentsRoutes = require('./routes/comments.js');
+const songsRoutes = require('./routes/songs.js');
 
 dotenv.config();
 const PORT = 8080;
@@ -49,6 +50,7 @@ app.use('/api', likesRoutes);
 app.use('/api', deezerRoutes);
 app.use('/api', suggUsersRoutes);
 app.use('/api', commentsRoutes);
+app.use('/api', songsRoutes);
 
 app.use(defaultRoute);
 app.use(invalidRoutes); // THIS HAS TO STAY LAST

--- a/frontend/src/components/common/Posts.jsx
+++ b/frontend/src/components/common/Posts.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Post from "./Post";
 import PostSkeleton from "../skeletons/PostSkeleton";
 import axios from "axios";
@@ -9,108 +9,134 @@ const Posts = ({ context, profileUserId }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [posts, setPosts] = useState([]);
     const [likedPosts, setLikedPosts] = useState([]);
-    const [accessToken, setAccessToken] = useState("")
+    const [accessToken, setAccessToken] = useState("");
+    const [page, setPage] = useState(1);
+    const [hasMore, setHasMore] = useState(true);
+    const observer = useRef();
 
     const getSpotifyAccessToken = async () => {
         const client_id = import.meta.env.VITE_CLIENT_ID;
         const client_secret = import.meta.env.VITE_CLIENT_SECRET;
         const response = await axios.post(
-          "https://accounts.spotify.com/api/token",
-          new URLSearchParams({ grant_type: "client_credentials" }),
-          {
-            headers: {
-              "Content-Type": "application/x-www-form-urlencoded",
-              Authorization: `Basic ${btoa(`${client_id}:${client_secret}`)}`,
-            },
-          }
+            "https://accounts.spotify.com/api/token",
+            new URLSearchParams({ grant_type: "client_credentials" }),
+            {
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    Authorization: `Basic ${btoa(`${client_id}:${client_secret}`)}`,
+                },
+            }
         );
         return response.data.access_token;
-      };
-    
-      // 1. Fetch Spotify token once on mount
-      useEffect(() => {
+    };
+
+    useEffect(() => {
         const fetchAccessToken = async () => {
-          try {
-            const token = await getSpotifyAccessToken();
-            setAccessToken(token);
-          } catch (err) {
-            console.error("Error fetching Spotify token:", err);
-          }
-        };
-        fetchAccessToken();
-      }, []);
-    
-
-        const fetchPosts = async () => {
             try {
-                setIsLoading(true); // Show loading indicator
-                // Retrieve the JWT from the cookie
-                const token = Cookies.get("tuneshare_cookie");
-                
-                if (!token) {
-                    console.error("No token found in cookie");
-                    return;
-                }
-
-                // Decode the JWT to extract user_id
-                const decodedToken = jwtDecode(token);
-                const userId = decodedToken.user_id;
-
-                if (!userId) {
-                    console.error("User ID not found in token");
-                    return;
-                }
-                
-                // Determine the user ID for the request
-                const targetUserId = context === "profile" ? profileUserId : userId;
-
-                // Fetch posts from the feed API
-                const response = await axios.post("/api/load-feed", {
-                    context: context,
-                    userid: targetUserId,
-                    page: 1,
-                });
-
-                if (response.data.success) {
-                    setPosts(response.data.data);
-                } else {
-                    console.error("Failed to fetch posts:", response.data.message);
-                }
-
-                const liked_posts = await axios.post("/api/user-liked-posts", {
-                    userID: userId
-                });
-                setLikedPosts(liked_posts.data);
-
-            } catch (error) {
-                console.error("Error fetching posts:", error);
-            } finally {
-                setIsLoading(false);
+                const token = await getSpotifyAccessToken();
+                setAccessToken(token);
+            } catch (err) {
+                console.error("Error fetching Spotify token:", err);
             }
         };
+        fetchAccessToken();
+    }, []);
 
-        useEffect(() => {
-            fetchPosts(); // Call fetchPosts when component mounts
-        }, []);
+    const fetchPosts = async (currentPage = page) => {
+        try {
+            setIsLoading(true);
+            const token = Cookies.get("tuneshare_cookie");
+            if (!token) return;
+
+            const decodedToken = jwtDecode(token);
+            const userId = decodedToken.user_id;
+            const targetUserId = context === "profile" ? profileUserId : userId;
+
+            const response = await axios.post("/api/load-feed", {
+                context: context,
+                userid: targetUserId,
+                page: currentPage,
+            });
+
+            if (response.data.success) {
+                if (currentPage === 1) {
+                    setPosts(response.data.data);
+                } else {
+                    setPosts((prev) => [...prev, ...response.data.data]);
+                }
+
+                if (response.data.data.length === 0) {
+                    setHasMore(false);
+                }
+            }
+
+            const liked_posts = await axios.post("/api/user-liked-posts", {
+                userID: userId,
+            });
+            setLikedPosts(liked_posts.data);
+        } catch (error) {
+            console.error("Error fetching posts:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchPosts(page);
+    }, [page]);
+
+    const lastPostRef = useCallback(
+        (node) => {
+            if (isLoading) return;
+            if (observer.current) observer.current.disconnect();
+            observer.current = new IntersectionObserver((entries) => {
+                if (entries[0].isIntersecting && hasMore) {
+                    setPage((prevPage) => prevPage + 1);
+                }
+            });
+            if (node) observer.current.observe(node);
+        },
+        [isLoading, hasMore]
+    );
 
     return (
         <>
-            {isLoading && (
+            {isLoading && page === 1 && (
                 <div className='flex flex-col justify-center'>
                     <PostSkeleton />
                     <PostSkeleton />
                     <PostSkeleton />
                 </div>
             )}
-            {!isLoading && posts?.length === 0 && <p className='text-center my-4'>No posts in this tab. Switch 👻</p>}
-            {!isLoading && posts && (
-                <div>
-                    {posts.map((post) => (
-                        <Post key={post._id} post={post} likedPosts={likedPosts} accessToken={accessToken} fetchPosts={fetchPosts}/>
-
-                    ))}
-                </div>
+            {!isLoading && posts?.length === 0 && (
+                <p className='text-center my-4'>No posts in this tab. Switch 👻</p>
             )}
+            <div>
+                {posts.map((post, index) => {
+                    if (posts.length === index + 1) {
+                        return (
+                            <div ref={lastPostRef} key={post._id}>
+                                <Post
+                                    post={post}
+                                    likedPosts={likedPosts}
+                                    accessToken={accessToken}
+                                    fetchPosts={() => fetchPosts(1)}
+                                />
+                            </div>
+                        );
+                    } else {
+                        return (
+                            <Post
+                                key={post._id}
+                                post={post}
+                                likedPosts={likedPosts}
+                                accessToken={accessToken}
+                                fetchPosts={() => fetchPosts(1)}
+                            />
+                        );
+                    }
+                })}
+            </div>
         </>
     );
 };


### PR DESCRIPTION
## cache + fetch song metadata from DB first, hit Spotify only if needed

### 🧩 Model
- Tweaked the `Song` schema:
  - Stores both `preview_url` (Spotify) and `deezer_preview_url`.
  - Added `deezer_entire_song_url` for when we need the full track later.

### 🛠 Backend
- Added `/api/song-metadata` POST route:
  - Grabs the Spotify track ID from the URL.
  - Checks if the song’s already in MongoDB (our local cache).
  - If it’s not:
    - Hits the Spotify API to get metadata.
    - Falls back to Deezer if there’s no Spotify preview.
    - Saves everything (Spotify + Deezer) to the DB.
  - Returns whether the data came from `"db"` or `"spotify"`.
  - Logs which source was used + song name to console.

### 🖥 Frontend
- Moved `getSpotifyTrackMetadata()` inside the `Post` component so each post handles its own caching.
- Using the new backend route to take advantage of that sweet DB cache.
- Detects if preview is from Spotify or Deezer and logs that.
- Using `useState` to cache:
  - Metadata
  - Preview URL
- No more unnecessary re-fetching on re-renders.
- Set up to work nicely with infinite scroll down the line.


## 🔄 add infinite scroll to feed page, appends posts page by page without reloading old ones