### PR TITLE
adding TTL to cached song metadata

### DIFF
--- a/backend/models/songs.js
+++ b/backend/models/songs.js
@@ -18,8 +18,10 @@ const songSchema = new mongoose.Schema(
         deezer_url: { type: String},
     
         created_at: { type: Date, default: Date.now }
-    }
+    },
+    { timestamps: true}
 );
 
+songSchema.index({ updatedAt: 1}, {expireAfterSeconds: 60*60*24*3});
 const Song = mongoose.model('Song', songSchema);
 module.exports = Song;


### PR DESCRIPTION
cached song preview links would return 403 Forbidden after a few days of being stored in our DB

now cached song metadata only lives for 3 days and it's created again if a request is made to fetch that song's metadata after that amount of time

this ensures that we use a recent access token for the metadata we are caching